### PR TITLE
support for node v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,27 @@
 {
   "name": "node-kpathsea",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "1.1.0",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "bindings": {
+  "packages": {
+    "": {
+      "name": "node-kpathsea",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "nan": "^2.19.0"
+      }
+    },
+    "node_modules/bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    "node_modules/nan": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-kpathsea",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Node bindings for the kpathsea library",
   "main": "lib/index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/xymostech/node-pathsea#readme",
   "dependencies": {
     "bindings": "^1.3.0",
-    "nan": "^2.14.2"
+    "nan": "^2.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-kpathsea",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Node bindings for the kpathsea library",
   "main": "lib/index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/xymostech/node-pathsea#readme",
   "dependencies": {
     "bindings": "^1.3.0",
-    "nan": "^2.8.0"
+    "nan": "^2.14.2"
   }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,12 @@
 { pkgs ? import <nixpkgs> {} }:
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
-    nativeBuildInputs = [ pkgs.nodePackages.node-gyp ];
+    nativeBuildInputs = [
+      pkgs.nodePackages.node-gyp
+      pkgs.python3
+    ];
     LDFLAGS="-L${pkgs.texlive.bin.core}/lib";
-    CXXFLAGS="-I${pkgs.texlive.bin.core}/include";
+    CXXFLAGS="-I${pkgs.texlive.bin.core.dev}/include";
   }
  
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
     nativeBuildInputs = [ pkgs.nodePackages.node-gyp ];
-    CFLAGS_CC="-I${pkgs.texlive.bin.core}/include";
+    LDFLAGS="-L${pkgs.texlive.bin.core}/lib";
     CXXFLAGS="-I${pkgs.texlive.bin.core}/include";
   }
  

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    # nativeBuildInputs is usually what you want -- tools you need to run
+    # nativeBuildInputs = [ pkgs.texlive.bin ];
+    CFLAGS_CC="-I${pkgs.texlive.bin.core}/include";
+  }
+ 
+

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,9 @@
 { pkgs ? import <nixpkgs> {} }:
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
-    # nativeBuildInputs = [ pkgs.texlive.bin ];
+    nativeBuildInputs = [ pkgs.nodePackages.node-gyp ];
     CFLAGS_CC="-I${pkgs.texlive.bin.core}/include";
+    CXXFLAGS="-I${pkgs.texlive.bin.core}/include";
   }
  
 

--- a/src/node_kpathsea.h
+++ b/src/node_kpathsea.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <nan.h>
-#include <kpathsea/kpathsea.h>
+#include <kpathsea/tex-file.h>
+#include <kpathsea/progname.h>
 
 class Kpathsea : public Nan::ObjectWrap {
 public:

--- a/src/node_kpathsea.h
+++ b/src/node_kpathsea.h
@@ -5,8 +5,7 @@
 
 class Kpathsea : public Nan::ObjectWrap {
 public:
-  static NAN_MODULE_INIT(Initialize);
-  //static void Initialize(v8::Local<v8::Object> target);
+    static NAN_MODULE_INIT(Initialize);
 
     enum FileFormatType {
         GF,

--- a/src/node_kpathsea.h
+++ b/src/node_kpathsea.h
@@ -5,7 +5,8 @@
 
 class Kpathsea : public Nan::ObjectWrap {
 public:
-    static void Initialize(v8::Handle<v8::Object> target);
+  static NAN_MODULE_INIT(Initialize);
+  //static void Initialize(v8::Local<v8::Object> target);
 
     enum FileFormatType {
         GF,


### PR DESCRIPTION
Node-gyp was unhappy with the published version, so this update fixes node-kpathsea to work on node v12.